### PR TITLE
chore: Bump ver: 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-more"
 description = "helper to display various types"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Rust utility crate providing enhanced display formatting for various types.
 
 ## Features
 
-- **Display Option**: Format `Option<T>` values with customizable display
+- **Display Option**: Format `Option<T>` values via `Display` or `Debug`
 - **Display Result**: Format `Result<T, E>` values
 - **Display Slice**: Format slices with configurable element limits
 - **Display Unix Epoch**: Convert Unix timestamps to human-readable datetime strings
@@ -31,6 +31,7 @@ println!("{}", value.display());  // "42"
 let none: Option<i32> = None;
 println!("{}", none.display());   // "None"
 ```
+
 
 ### Display Result
 


### PR DESCRIPTION

## Changelog

##### chore: Bump ver: 0.2.2

##### docs: mention `Debug` formatting support in README
Update the Display Option feature description to reflect the newly added
`display_debug()` capability.


##### feat: add `display_debug()` for formatting `Option<T>` via `Debug`
`DisplayOption` now stores a format function pointer (`fmt_fn`) instead of
requiring `T: Display` on the struct. This lets the same wrapper support both
`Display` and `Debug` formatting, selected at construction time.

`DisplayOptionExt::display()` sets `fmt_fn` to `Display::fmt` (unchanged
behavior). The new `DisplayDebugOptionExt::display_debug()` sets it to
`Debug::fmt`, useful for types that implement `Debug` but not `Display`
(e.g., `Vec<T>`).

Changes:
- Replace tuple struct with named fields (`inner`, `fmt_fn`)
- Remove `T: Display` bound from `DisplayOption` struct and its `Display` impl
- Add `DisplayDebugOptionExt` trait with `.display_debug()` method


##### chore: bump ver 0.2.1

##### chore: prepare crate for crates.io publication
Add complete crates.io metadata to `Cargo.toml` including repository,
homepage, documentation URLs, readme field, keywords, and categories
to ensure proper discoverability on crates.io.

Update README.md with corrected trait names in examples
(DisplayOptionExt, DisplayResultExt, DisplaySliceExt,
DisplayUnixTimeStampExt), add missing DisplayResult example, and
update version from 0.1.0 to 0.2.0. Remove unnecessary sections for
improved clarity.

Enhance crate-level documentation in lib.rs with comprehensive
examples for all four extension traits (Option, Result, Slice, Unix
Timestamp) to provide better API documentation on docs.rs.

---


