### PR TITLE
chore: Bump ver: 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-more"
 description = "helper to display various types"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION

## Changelog

##### chore: Bump ver: 0.2.3

##### feat: add customizable separator for `DisplaySlice`
`DisplaySlice` previously hardcoded `","` as the element separator.
Add a `sep()` builder method so users can choose their own delimiter
(e.g. `", "`, `" | "`, `""`), keeping the existing default unchanged.

Example:

    vec![1, 2, 3].display().sep(", ")       // "[1, 2, 3]"
    vec![1, 2, 3, 4, 5, 6].display_n(2).sep("|")  // "[1|..|6]"

---


