### PR TITLE
feat: add customizable ellipsis, element prefix/suffix, and show-count for `DisplaySlice`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-more"
 description = "helper to display various types"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION

## Changelog

##### feat: add customizable ellipsis, element prefix/suffix, and show-count for `DisplaySlice`
Three new builder methods extend `DisplaySlice` formatting:
- `.ellipsis(s)` replaces the hardcoded `..` truncation indicator with any string
- `.elem(prefix, suffix)` wraps each displayed element (but not the ellipsis)
- `.show_count()` appends `(N total)` to the ellipsis when truncation occurs

The `show_count` feature only allocates a `format!` string when both active and
truncation is needed; the common path remains allocation-free.

Example:

    vec![1,2,3,4,5,6,7].display()
        .ellipsis("...").show_count().elem("'", "'").sep(", ").braces("{", "}")
    // => {'1', '2', '3', '4', ...(7 total), '7'}


##### feat: add customizable braces for `DisplaySlice`
`DisplaySlice` previously hardcoded `[` and `]` as surrounding braces.
This adds a `braces()` builder method to configure them, following the
same pattern as `sep()`. Defaults remain `[` / `]` for backward
compatibility.

Example:

    vec![1, 2, 3].display().braces("{", "}").to_string()
    // => "{1,2,3}"

    vec![1, 2, 3].display().braces("<", ">").sep(", ").to_string()
    // => "<1, 2, 3>"


##### chore: Bump ver: 0.2.4

---


