### PR TITLE
feat: impl `DisplayUnixTimeStampExt` for `Option<Duration>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-more"
 description = "helper to display various types"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION

## Changelog

##### feat: impl `DisplayUnixTimeStampExt` for `Option<Duration>`
Timestamps are often optional (e.g., "last seen at"), so accepting
`Option<Duration>` directly avoids callers needing to unwrap before
formatting. `None` renders as the literal string `"None"`, matching the
convention used by `DisplayOption`.

Internally, `DisplayUnixTimeStamp::duration` is now `Option<Duration>`;
the `Display` impl early-returns `"None"` for `None`.

Example:

    let ts: Option<Duration> = None;
    assert_eq!(ts.display_unix_timestamp().to_string(), "None");

    let ts = Some(Duration::from_millis(1723102819023));
    assert_eq!(ts.display_unix_timestamp_short().to_string(), "2024-08-08T07:40:19.023");


##### chore: Bump ver: 0.2.5

---


