### PR TITLE
test: add edge-case and formatting tests

### DIFF
--- a/src/display_btreeset.rs
+++ b/src/display_btreeset.rs
@@ -183,4 +183,20 @@ mod tests {
                 .to_string()
         );
     }
+
+    #[test]
+    fn test_display_btreeset_limit_getter_and_large_limit() {
+        let set = (1..=3).collect::<BTreeSet<_>>();
+
+        let display = DisplayBTreeSet::new(&set);
+        assert_eq!(5, display.limit());
+        assert_eq!(10, display.at_most(Some(10)).limit());
+        assert_eq!("[1,2,3]", set.display_n(10).to_string());
+    }
+
+    #[test]
+    fn test_display_btreeset_show_count_without_truncation() {
+        let set = (1..=3).collect::<BTreeSet<_>>();
+        assert_eq!("[1,2,3]", DisplayBTreeSet::new(&set).show_count().to_string());
+    }
 }

--- a/src/display_btreeset.rs
+++ b/src/display_btreeset.rs
@@ -1,0 +1,186 @@
+use std::collections::BTreeSet;
+use std::fmt;
+
+use crate::DisplayIntoIter;
+
+/// Implement `Display` for `BTreeSet<T>` if `T` is `Display`.
+///
+/// It outputs at most `limit` elements, excluding those from the 5th to the second-to-last one:
+/// - `DisplayBTreeSet{ set: ... }` outputs: `"[1,2,3,4,..,6]"`.
+pub struct DisplayBTreeSet<'a, T: fmt::Display> {
+    inner: DisplayIntoIter<'a, T, &'a BTreeSet<T>>,
+}
+
+impl<'a, T: fmt::Display> DisplayBTreeSet<'a, T> {
+    pub fn new(set: &'a BTreeSet<T>) -> Self {
+        Self {
+            inner: DisplayIntoIter::new(set),
+        }
+    }
+
+    pub fn at_most(mut self, limit: Option<usize>) -> Self {
+        self.inner = self.inner.at_most(limit);
+        self
+    }
+
+    pub fn sep(mut self, separator: &'a str) -> Self {
+        self.inner = self.inner.sep(separator);
+        self
+    }
+
+    pub fn braces(mut self, left: &'a str, right: &'a str) -> Self {
+        self.inner = self.inner.braces(left, right);
+        self
+    }
+
+    pub fn ellipsis(mut self, s: &'a str) -> Self {
+        self.inner = self.inner.ellipsis(s);
+        self
+    }
+
+    pub fn elem(mut self, prefix: &'a str, suffix: &'a str) -> Self {
+        self.inner = self.inner.elem(prefix, suffix);
+        self
+    }
+
+    pub fn show_count(mut self) -> Self {
+        self.inner = self.inner.show_count();
+        self
+    }
+
+    pub fn limit(&self) -> usize {
+        self.inner.limit()
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for DisplayBTreeSet<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+/// Implement `Display` for `BTreeSet<T>` if `T` is `Display`.
+///
+/// It outputs at most `MAX` elements, excluding those from the 5th to the second-to-last one:
+/// - `DisplayBTreeSet([1,2,3,4,5,6])` outputs: `"[1,2,3,4,..,6]"`.
+///
+/// # Example
+///
+/// ```rust
+/// use std::collections::BTreeSet;
+///
+/// use display_more::DisplayBTreeSetExt;
+///
+/// let a = (1..=6).collect::<BTreeSet<_>>();
+/// assert_eq!(a.display().to_string(), "[1,2,3,4,..,6]");
+/// ```
+pub trait DisplayBTreeSetExt<'a, T: fmt::Display> {
+    fn display(&'a self) -> DisplayBTreeSet<'a, T>;
+
+    /// Display at most `n` elements.
+    fn display_n(&'a self, n: usize) -> DisplayBTreeSet<'a, T> {
+        self.display().at_most(Some(n))
+    }
+}
+
+impl<T> DisplayBTreeSetExt<'_, T> for BTreeSet<T>
+where T: fmt::Display
+{
+    fn display(&self) -> DisplayBTreeSet<'_, T> {
+        DisplayBTreeSet::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::DisplayBTreeSet;
+    use crate::DisplayBTreeSetExt;
+
+    #[test]
+    fn test_display_btreeset() {
+        let set = (1..=3).collect::<BTreeSet<_>>();
+        let display = DisplayBTreeSet::new(&set);
+
+        assert_eq!(display.to_string(), "[1,2,3]");
+    }
+
+    #[test]
+    fn test_display_empty_set() {
+        let set = BTreeSet::<i32>::new();
+        let display = DisplayBTreeSet::new(&set);
+
+        assert_eq!(display.to_string(), "[]");
+    }
+
+    #[test]
+    fn test_display_btreeset_with_1_item() {
+        let set = (1..=1).collect::<BTreeSet<_>>();
+        let display = DisplayBTreeSet::new(&set);
+
+        assert_eq!(display.to_string(), "[1]");
+    }
+
+    #[test]
+    fn test_display_btreeset_limit() {
+        let set = (1..=7).collect::<BTreeSet<_>>();
+
+        assert_eq!("[1,2,3,4,..,7]", set.display().to_string());
+        assert_eq!("[1,..,7]", set.display_n(2).to_string());
+        assert_eq!("[..,7]", set.display_n(1).to_string());
+        assert_eq!("[..]", set.display_n(0).to_string());
+    }
+
+    #[test]
+    fn test_display_btreeset_separator_and_braces() {
+        let set = (1..=6).collect::<BTreeSet<_>>();
+
+        assert_eq!("[1, 2, 3, 4, .., 6]", set.display().sep(", ").to_string());
+        assert_eq!(
+            "{1|..|6}",
+            set.display_n(2).sep("|").braces("{", "}").to_string()
+        );
+        assert_eq!(
+            "1,2,3",
+            (1..=3)
+                .collect::<BTreeSet<_>>()
+                .display()
+                .braces("", "")
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn test_display_btreeset_ellipsis_and_elem() {
+        let set = (1..=6).collect::<BTreeSet<_>>();
+
+        assert_eq!("[1,2,3,4,...,6]", set.display().ellipsis("...").to_string());
+        assert_eq!(
+            "['1','2','3','4',..,'6']",
+            set.display().elem("'", "'").to_string()
+        );
+        assert_eq!("[...]", set.display_n(0).ellipsis("...").to_string());
+    }
+
+    #[test]
+    fn test_display_btreeset_show_count() {
+        let set = (1..=7).collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            "[1,2,3,4,..(7 total),7]",
+            set.display().show_count().to_string()
+        );
+        assert_eq!("[..(7 total)]", set.display_n(0).show_count().to_string());
+        assert_eq!(
+            "{'1', '2', '3', '4', ...(7 total), '7'}",
+            set.display()
+                .ellipsis("...")
+                .show_count()
+                .elem("'", "'")
+                .sep(", ")
+                .braces("{", "}")
+                .to_string()
+        );
+    }
+}

--- a/src/display_into_iter.rs
+++ b/src/display_into_iter.rs
@@ -1,0 +1,163 @@
+use std::fmt;
+
+/// Implement `Display` for cloneable iter sources that yield `&T`.
+///
+/// It outputs at most `limit` elements, excluding those from the 5th to the second-to-last one.
+pub struct DisplayIntoIter<'a, T, S>
+where
+    T: fmt::Display + 'a,
+    S: Clone + IntoIterator<Item = &'a T>,
+    S::IntoIter: DoubleEndedIterator + ExactSizeIterator,
+{
+    items: S,
+    /// The maximum number of elements to display. by default, it is 5.
+    limit: Option<usize>,
+    /// The separator between elements. by default, it is ",".
+    separator: &'a str,
+    /// The left brace. by default, it is "[".
+    left_brace: &'a str,
+    /// The right brace. by default, it is "]".
+    right_brace: &'a str,
+    /// The ellipsis string. by default, it is "..".
+    ellipsis: &'a str,
+    /// The prefix for each element. by default, it is "".
+    elem_prefix: &'a str,
+    /// The suffix for each element. by default, it is "".
+    elem_suffix: &'a str,
+    /// Whether to show the total count when truncated. by default, it is false.
+    show_count: bool,
+}
+
+impl<'a, T, S> DisplayIntoIter<'a, T, S>
+where
+    T: fmt::Display + 'a,
+    S: Clone + IntoIterator<Item = &'a T>,
+    S::IntoIter: DoubleEndedIterator + ExactSizeIterator,
+{
+    pub fn new(items: S) -> Self {
+        Self {
+            items,
+            limit: None,
+            separator: ",",
+            left_brace: "[",
+            right_brace: "]",
+            ellipsis: "..",
+            elem_prefix: "",
+            elem_suffix: "",
+            show_count: false,
+        }
+    }
+
+    pub fn at_most(mut self, limit: Option<usize>) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    pub fn sep(mut self, separator: &'a str) -> Self {
+        self.separator = separator;
+        self
+    }
+
+    pub fn braces(mut self, left: &'a str, right: &'a str) -> Self {
+        self.left_brace = left;
+        self.right_brace = right;
+        self
+    }
+
+    pub fn ellipsis(mut self, s: &'a str) -> Self {
+        self.ellipsis = s;
+        self
+    }
+
+    pub fn elem(mut self, prefix: &'a str, suffix: &'a str) -> Self {
+        self.elem_prefix = prefix;
+        self.elem_suffix = suffix;
+        self
+    }
+
+    pub fn show_count(mut self) -> Self {
+        self.show_count = true;
+        self
+    }
+
+    pub fn limit(&self) -> usize {
+        self.limit.unwrap_or(5)
+    }
+}
+
+impl<'a, T, S> fmt::Display for DisplayIntoIter<'a, T, S>
+where
+    T: fmt::Display + 'a,
+    S: Clone + IntoIterator<Item = &'a T>,
+    S::IntoIter: DoubleEndedIterator + ExactSizeIterator,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let limit = self.limit();
+        let len = self.items.clone().into_iter().len();
+        let truncated = len > limit;
+
+        let ell;
+        let ellipsis = if self.show_count && truncated {
+            ell = format!("{}({len} total)", self.ellipsis);
+            &ell
+        } else {
+            self.ellipsis
+        };
+
+        if limit == 0 {
+            return write!(f, "{}{ellipsis}{}", self.left_brace, self.right_brace);
+        }
+
+        write!(f, "{}", self.left_brace)?;
+
+        let (pre, suf, sep) = (self.elem_prefix, self.elem_suffix, self.separator);
+
+        if truncated {
+            let mut iter = self.items.clone().into_iter();
+
+            for _ in 0..(limit - 1) {
+                let item = iter.next().unwrap();
+                write!(f, "{pre}{item}{suf}{sep}")?;
+            }
+
+            write!(f, "{ellipsis}{sep}")?;
+            write!(
+                f,
+                "{pre}{}{suf}",
+                self.items.clone().into_iter().next_back().unwrap()
+            )?;
+        } else {
+            for (i, item) in self.items.clone().into_iter().enumerate() {
+                if i > 0 {
+                    write!(f, "{sep}")?;
+                }
+
+                write!(f, "{pre}{item}{suf}")?;
+            }
+        }
+
+        write!(f, "{}", self.right_brace)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::DisplayIntoIter;
+
+    #[test]
+    fn test_display_into_iter_slice() {
+        let values = [1, 2, 3, 4, 5, 6];
+        assert_eq!(
+            "[1,2,3,4,..,6]",
+            DisplayIntoIter::new(values.iter()).to_string()
+        );
+    }
+
+    #[test]
+    fn test_display_into_iter_btreeset() {
+        let values = (1..=6).collect::<BTreeSet<_>>();
+        assert_eq!("[1,2,3,4,..,6]", DisplayIntoIter::new(&values).to_string());
+    }
+}

--- a/src/display_into_iter.rs
+++ b/src/display_into_iter.rs
@@ -146,6 +146,18 @@ mod tests {
 
     use super::DisplayIntoIter;
 
+    #[derive(Clone)]
+    struct Items<'a, T>(&'a [T]);
+
+    impl<'a, T> IntoIterator for Items<'a, T> {
+        type Item = &'a T;
+        type IntoIter = std::slice::Iter<'a, T>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.iter()
+        }
+    }
+
     #[test]
     fn test_display_into_iter_slice() {
         let values = [1, 2, 3, 4, 5, 6];
@@ -159,5 +171,40 @@ mod tests {
     fn test_display_into_iter_btreeset() {
         let values = (1..=6).collect::<BTreeSet<_>>();
         assert_eq!("[1,2,3,4,..,6]", DisplayIntoIter::new(&values).to_string());
+    }
+
+    #[test]
+    fn test_display_into_iter_custom_container() {
+        let values = [1, 2, 3, 4, 5, 6];
+        assert_eq!(
+            "[1,2,..,6]",
+            DisplayIntoIter::new(Items(&values))
+                .at_most(Some(3))
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn test_display_into_iter_limit_edges() {
+        let values = [1, 2, 3, 4, 5, 6];
+
+        assert_eq!("[..]", DisplayIntoIter::new(values.iter()).at_most(Some(0)).to_string());
+        assert_eq!("[..,6]", DisplayIntoIter::new(values.iter()).at_most(Some(1)).to_string());
+    }
+
+    #[test]
+    fn test_display_into_iter_combined_formatting() {
+        let values = [1, 2, 3, 4, 5, 6, 7];
+
+        assert_eq!(
+            "{'1' | '2' | '3' | '4' | ...(7 total) | '7'}",
+            DisplayIntoIter::new(values.iter())
+                .ellipsis("...")
+                .show_count()
+                .elem("'", "'")
+                .sep(" | ")
+                .braces("{", "}")
+                .to_string()
+        );
     }
 }

--- a/src/display_slice.rs
+++ b/src/display_slice.rs
@@ -14,123 +14,61 @@
 
 use std::fmt;
 
+use crate::DisplayIntoIter;
+
 /// Implement `Display` for `&[T]` if T is `Display`.
 ///
 /// It outputs at most `limit` elements, excluding those from the 5th to the second-to-last one:
 /// - `DisplaySlice{ slice: &[1,2,3,4,5,6], ...}` outputs: `"[1,2,3,4,...,6]"`.
 pub struct DisplaySlice<'a, T: fmt::Display> {
-    slice: &'a [T],
-    /// The maximum number of elements to display. by default, it is 5.
-    limit: Option<usize>,
-    /// The separator between elements. by default, it is ",".
-    separator: &'a str,
-    /// The left brace. by default, it is "[".
-    left_brace: &'a str,
-    /// The right brace. by default, it is "]".
-    right_brace: &'a str,
-    /// The ellipsis string. by default, it is "..".
-    ellipsis: &'a str,
-    /// The prefix for each element. by default, it is "".
-    elem_prefix: &'a str,
-    /// The suffix for each element. by default, it is "".
-    elem_suffix: &'a str,
-    /// Whether to show the total count when truncated. by default, it is false.
-    show_count: bool,
+    inner: DisplayIntoIter<'a, T, std::slice::Iter<'a, T>>,
 }
 
 impl<'a, T: fmt::Display> DisplaySlice<'a, T> {
     pub fn new(slice: &'a [T]) -> Self {
         Self {
-            slice,
-            limit: None,
-            separator: ",",
-            left_brace: "[",
-            right_brace: "]",
-            ellipsis: "..",
-            elem_prefix: "",
-            elem_suffix: "",
-            show_count: false,
+            inner: DisplayIntoIter::new(slice.iter()),
         }
     }
 
     pub fn at_most(mut self, limit: Option<usize>) -> Self {
-        self.limit = limit;
+        self.inner = self.inner.at_most(limit);
         self
     }
 
     pub fn sep(mut self, separator: &'a str) -> Self {
-        self.separator = separator;
+        self.inner = self.inner.sep(separator);
         self
     }
 
     pub fn braces(mut self, left: &'a str, right: &'a str) -> Self {
-        self.left_brace = left;
-        self.right_brace = right;
+        self.inner = self.inner.braces(left, right);
         self
     }
 
     pub fn ellipsis(mut self, s: &'a str) -> Self {
-        self.ellipsis = s;
+        self.inner = self.inner.ellipsis(s);
         self
     }
 
     pub fn elem(mut self, prefix: &'a str, suffix: &'a str) -> Self {
-        self.elem_prefix = prefix;
-        self.elem_suffix = suffix;
+        self.inner = self.inner.elem(prefix, suffix);
         self
     }
 
     pub fn show_count(mut self) -> Self {
-        self.show_count = true;
+        self.inner = self.inner.show_count();
         self
     }
 
     pub fn limit(&self) -> usize {
-        self.limit.unwrap_or(5)
+        self.inner.limit()
     }
 }
 
 impl<T: fmt::Display> fmt::Display for DisplaySlice<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let limit = self.limit();
-        let slice = self.slice;
-        let len = slice.len();
-        let truncated = len > limit;
-
-        let ell;
-        let ellipsis = if self.show_count && truncated {
-            ell = format!("{}({len} total)", self.ellipsis);
-            &ell
-        } else {
-            self.ellipsis
-        };
-
-        if limit == 0 {
-            return write!(f, "{}{ellipsis}{}", self.left_brace, self.right_brace);
-        }
-
-        write!(f, "{}", self.left_brace)?;
-
-        let (pre, suf, sep) = (self.elem_prefix, self.elem_suffix, self.separator);
-
-        if truncated {
-            for t in slice[..(limit - 1)].iter() {
-                write!(f, "{pre}{t}{suf}{sep}")?;
-            }
-
-            write!(f, "{ellipsis}{sep}")?;
-            write!(f, "{pre}{}{suf}", slice.last().unwrap())?;
-        } else {
-            for (i, t) in slice.iter().enumerate() {
-                if i > 0 {
-                    write!(f, "{sep}")?;
-                }
-
-                write!(f, "{pre}{t}{suf}")?;
-            }
-        }
-
-        write!(f, "{}", self.right_brace)
+        self.inner.fmt(f)
     }
 }
 

--- a/src/display_unix_epoch.rs
+++ b/src/display_unix_epoch.rs
@@ -132,6 +132,12 @@ mod tests {
         let display = epoch.display_unix_timestamp_short();
         assert_eq!(format!("{}", display), "2024-08-08T07:40:19.023");
 
+        let display = epoch.display_unix_timestamp().in_millis(true);
+        assert_eq!(format!("{}", display), "2024-08-08T07:40:19.023Z+0000");
+
+        let display = epoch.display_unix_timestamp().with_timezone(false);
+        assert_eq!(format!("{}", display), "2024-08-08T07:40:19.023000");
+
         // Option<Duration>: Some
         let some = Some(Duration::from_millis(1723102819023));
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,16 @@
 //! );
 //! ```
 
+mod display_btreeset;
+mod display_into_iter;
 pub mod display_option;
 mod display_result;
 pub mod display_slice;
 pub mod display_unix_epoch;
 
+pub use display_btreeset::DisplayBTreeSet;
+pub use display_btreeset::DisplayBTreeSetExt;
+pub use display_into_iter::DisplayIntoIter;
 pub use display_option::DisplayDebugOptionExt;
 pub use display_option::DisplayOptionExt;
 pub use display_result::DisplayResultExt;


### PR DESCRIPTION

## Changelog

##### test: add edge-case and formatting tests
Add tests for `DisplayIntoIter`, `DisplayBTreeSet`, and
`DisplayUnixTimestamp` to cover edge cases not previously tested:
custom container types with `IntoIterator`, limit boundary values
(0 and 1), combined formatting options, `show_count` without
truncation, and `in_millis`/`with_timezone` display variants.


##### feat: extract `DisplayIntoIter` and add `DisplayBTreeSet`
Extract the truncated-display logic from `DisplaySlice` into a generic
`DisplayIntoIter<T, S>` that works with any cloneable iterator source
yielding `&T`. `DisplaySlice` now delegates to it, eliminating duplicated
formatting code.

Add `DisplayBTreeSet` as a thin wrapper over `DisplayIntoIter`, bringing
the same truncated display with customizable braces, separator, ellipsis,
element prefix/suffix, and show-count to `BTreeSet<T>`.

Changes:
- Add `DisplayIntoIter` generic over `S: Clone + IntoIterator<Item = &T>`
- Add `DisplayBTreeSet` and `DisplayBTreeSetExt` trait
- Refactor `DisplaySlice` to delegate to `DisplayIntoIter`

---

- Improvement
- Build/Testing/CI
