### PR TITLE
refactor: extract formatting options into `DisplayIteratorOptions`

### DIFF
--- a/src/display_into_iter.rs
+++ b/src/display_into_iter.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::display_iterator_options::DisplayIteratorOptions;
+
 /// Implement `Display` for cloneable iter sources that yield `&T`.
 ///
 /// It outputs at most `limit` elements, excluding those from the 5th to the second-to-last one.
@@ -10,22 +12,7 @@ where
     S::IntoIter: DoubleEndedIterator + ExactSizeIterator,
 {
     items: S,
-    /// The maximum number of elements to display. by default, it is 5.
-    limit: Option<usize>,
-    /// The separator between elements. by default, it is ",".
-    separator: &'a str,
-    /// The left brace. by default, it is "[".
-    left_brace: &'a str,
-    /// The right brace. by default, it is "]".
-    right_brace: &'a str,
-    /// The ellipsis string. by default, it is "..".
-    ellipsis: &'a str,
-    /// The prefix for each element. by default, it is "".
-    elem_prefix: &'a str,
-    /// The suffix for each element. by default, it is "".
-    elem_suffix: &'a str,
-    /// Whether to show the total count when truncated. by default, it is false.
-    show_count: bool,
+    options: DisplayIteratorOptions<'a>,
 }
 
 impl<'a, T, S> DisplayIntoIter<'a, T, S>
@@ -37,51 +24,44 @@ where
     pub fn new(items: S) -> Self {
         Self {
             items,
-            limit: None,
-            separator: ",",
-            left_brace: "[",
-            right_brace: "]",
-            ellipsis: "..",
-            elem_prefix: "",
-            elem_suffix: "",
-            show_count: false,
+            options: DisplayIteratorOptions::default(),
         }
     }
 
     pub fn at_most(mut self, limit: Option<usize>) -> Self {
-        self.limit = limit;
+        self.options.limit = limit;
         self
     }
 
     pub fn sep(mut self, separator: &'a str) -> Self {
-        self.separator = separator;
+        self.options.separator = separator;
         self
     }
 
     pub fn braces(mut self, left: &'a str, right: &'a str) -> Self {
-        self.left_brace = left;
-        self.right_brace = right;
+        self.options.left_brace = left;
+        self.options.right_brace = right;
         self
     }
 
     pub fn ellipsis(mut self, s: &'a str) -> Self {
-        self.ellipsis = s;
+        self.options.ellipsis = s;
         self
     }
 
     pub fn elem(mut self, prefix: &'a str, suffix: &'a str) -> Self {
-        self.elem_prefix = prefix;
-        self.elem_suffix = suffix;
+        self.options.elem_prefix = prefix;
+        self.options.elem_suffix = suffix;
         self
     }
 
     pub fn show_count(mut self) -> Self {
-        self.show_count = true;
+        self.options.show_count = true;
         self
     }
 
     pub fn limit(&self) -> usize {
-        self.limit.unwrap_or(5)
+        self.options.limit()
     }
 }
 
@@ -95,22 +75,23 @@ where
         let limit = self.limit();
         let len = self.items.clone().into_iter().len();
         let truncated = len > limit;
+        let options = &self.options;
 
         let ell;
-        let ellipsis = if self.show_count && truncated {
-            ell = format!("{}({len} total)", self.ellipsis);
+        let ellipsis = if options.show_count && truncated {
+            ell = format!("{}({len} total)", options.ellipsis);
             &ell
         } else {
-            self.ellipsis
+            options.ellipsis
         };
 
         if limit == 0 {
-            return write!(f, "{}{ellipsis}{}", self.left_brace, self.right_brace);
+            return write!(f, "{}{ellipsis}{}", options.left_brace, options.right_brace);
         }
 
-        write!(f, "{}", self.left_brace)?;
+        write!(f, "{}", options.left_brace)?;
 
-        let (pre, suf, sep) = (self.elem_prefix, self.elem_suffix, self.separator);
+        let (pre, suf, sep) = (options.elem_prefix, options.elem_suffix, options.separator);
 
         if truncated {
             let mut iter = self.items.clone().into_iter();
@@ -136,7 +117,7 @@ where
             }
         }
 
-        write!(f, "{}", self.right_brace)
+        write!(f, "{}", options.right_brace)
     }
 }
 

--- a/src/display_iterator_options.rs
+++ b/src/display_iterator_options.rs
@@ -1,0 +1,39 @@
+pub(crate) struct DisplayIteratorOptions<'a> {
+    /// The maximum number of elements to display. by default, it is 5.
+    pub(crate) limit: Option<usize>,
+    /// The separator between elements. by default, it is ",".
+    pub(crate) separator: &'a str,
+    /// The left brace. by default, it is "[".
+    pub(crate) left_brace: &'a str,
+    /// The right brace. by default, it is "]".
+    pub(crate) right_brace: &'a str,
+    /// The ellipsis string. by default, it is "..".
+    pub(crate) ellipsis: &'a str,
+    /// The prefix for each element. by default, it is "".
+    pub(crate) elem_prefix: &'a str,
+    /// The suffix for each element. by default, it is "".
+    pub(crate) elem_suffix: &'a str,
+    /// Whether to show the total count when truncated. by default, it is false.
+    pub(crate) show_count: bool,
+}
+
+impl<'a> Default for DisplayIteratorOptions<'a> {
+    fn default() -> Self {
+        Self {
+            limit: None,
+            separator: ",",
+            left_brace: "[",
+            right_brace: "]",
+            ellipsis: "..",
+            elem_prefix: "",
+            elem_suffix: "",
+            show_count: false,
+        }
+    }
+}
+
+impl<'a> DisplayIteratorOptions<'a> {
+    pub(crate) fn limit(&self) -> usize {
+        self.limit.unwrap_or(5)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@
 
 mod display_btreeset;
 mod display_into_iter;
+mod display_iterator_options;
 pub mod display_option;
 mod display_result;
 pub mod display_slice;


### PR DESCRIPTION

## Changelog

##### refactor: extract formatting options into `DisplayIteratorOptions`
Move the formatting fields (limit, separator, braces, ellipsis, element
prefix/suffix, show_count) out of `DisplayIntoIter` into a dedicated
`DisplayIteratorOptions` struct. This separates the data source concern
(what to iterate) from the presentation concern (how to format), making
the options reusable and the iterator struct smaller.

---

- Improvement
