### PR TITLE
refactor: extract formatting options into `DisplayIteratorOptions`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
 
 
       - shell: bash
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --locked
 
 
       - name: Audit dependencies

--- a/src/display_btreeset.rs
+++ b/src/display_btreeset.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::BTreeSet;
 use std::fmt;
 
@@ -197,6 +211,9 @@ mod tests {
     #[test]
     fn test_display_btreeset_show_count_without_truncation() {
         let set = (1..=3).collect::<BTreeSet<_>>();
-        assert_eq!("[1,2,3]", DisplayBTreeSet::new(&set).show_count().to_string());
+        assert_eq!(
+            "[1,2,3]",
+            DisplayBTreeSet::new(&set).show_count().to_string()
+        );
     }
 }

--- a/src/display_into_iter.rs
+++ b/src/display_into_iter.rs
@@ -1,4 +1,20 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fmt;
+
+use crate::display_iterator_options::DisplayIteratorOptions;
 
 /// Implement `Display` for cloneable iter sources that yield `&T`.
 ///
@@ -10,22 +26,7 @@ where
     S::IntoIter: DoubleEndedIterator + ExactSizeIterator,
 {
     items: S,
-    /// The maximum number of elements to display. by default, it is 5.
-    limit: Option<usize>,
-    /// The separator between elements. by default, it is ",".
-    separator: &'a str,
-    /// The left brace. by default, it is "[".
-    left_brace: &'a str,
-    /// The right brace. by default, it is "]".
-    right_brace: &'a str,
-    /// The ellipsis string. by default, it is "..".
-    ellipsis: &'a str,
-    /// The prefix for each element. by default, it is "".
-    elem_prefix: &'a str,
-    /// The suffix for each element. by default, it is "".
-    elem_suffix: &'a str,
-    /// Whether to show the total count when truncated. by default, it is false.
-    show_count: bool,
+    options: DisplayIteratorOptions<'a>,
 }
 
 impl<'a, T, S> DisplayIntoIter<'a, T, S>
@@ -37,51 +38,44 @@ where
     pub fn new(items: S) -> Self {
         Self {
             items,
-            limit: None,
-            separator: ",",
-            left_brace: "[",
-            right_brace: "]",
-            ellipsis: "..",
-            elem_prefix: "",
-            elem_suffix: "",
-            show_count: false,
+            options: DisplayIteratorOptions::default(),
         }
     }
 
     pub fn at_most(mut self, limit: Option<usize>) -> Self {
-        self.limit = limit;
+        self.options.limit = limit;
         self
     }
 
     pub fn sep(mut self, separator: &'a str) -> Self {
-        self.separator = separator;
+        self.options.separator = separator;
         self
     }
 
     pub fn braces(mut self, left: &'a str, right: &'a str) -> Self {
-        self.left_brace = left;
-        self.right_brace = right;
+        self.options.left_brace = left;
+        self.options.right_brace = right;
         self
     }
 
     pub fn ellipsis(mut self, s: &'a str) -> Self {
-        self.ellipsis = s;
+        self.options.ellipsis = s;
         self
     }
 
     pub fn elem(mut self, prefix: &'a str, suffix: &'a str) -> Self {
-        self.elem_prefix = prefix;
-        self.elem_suffix = suffix;
+        self.options.elem_prefix = prefix;
+        self.options.elem_suffix = suffix;
         self
     }
 
     pub fn show_count(mut self) -> Self {
-        self.show_count = true;
+        self.options.show_count = true;
         self
     }
 
     pub fn limit(&self) -> usize {
-        self.limit.unwrap_or(5)
+        self.options.limit()
     }
 }
 
@@ -95,22 +89,23 @@ where
         let limit = self.limit();
         let len = self.items.clone().into_iter().len();
         let truncated = len > limit;
+        let options = &self.options;
 
         let ell;
-        let ellipsis = if self.show_count && truncated {
-            ell = format!("{}({len} total)", self.ellipsis);
+        let ellipsis = if options.show_count && truncated {
+            ell = format!("{}({len} total)", options.ellipsis);
             &ell
         } else {
-            self.ellipsis
+            options.ellipsis
         };
 
         if limit == 0 {
-            return write!(f, "{}{ellipsis}{}", self.left_brace, self.right_brace);
+            return write!(f, "{}{ellipsis}{}", options.left_brace, options.right_brace);
         }
 
-        write!(f, "{}", self.left_brace)?;
+        write!(f, "{}", options.left_brace)?;
 
-        let (pre, suf, sep) = (self.elem_prefix, self.elem_suffix, self.separator);
+        let (pre, suf, sep) = (options.elem_prefix, options.elem_suffix, options.separator);
 
         if truncated {
             let mut iter = self.items.clone().into_iter();
@@ -136,7 +131,7 @@ where
             }
         }
 
-        write!(f, "{}", self.right_brace)
+        write!(f, "{}", options.right_brace)
     }
 }
 
@@ -188,8 +183,18 @@ mod tests {
     fn test_display_into_iter_limit_edges() {
         let values = [1, 2, 3, 4, 5, 6];
 
-        assert_eq!("[..]", DisplayIntoIter::new(values.iter()).at_most(Some(0)).to_string());
-        assert_eq!("[..,6]", DisplayIntoIter::new(values.iter()).at_most(Some(1)).to_string());
+        assert_eq!(
+            "[..]",
+            DisplayIntoIter::new(values.iter())
+                .at_most(Some(0))
+                .to_string()
+        );
+        assert_eq!(
+            "[..,6]",
+            DisplayIntoIter::new(values.iter())
+                .at_most(Some(1))
+                .to_string()
+        );
     }
 
     #[test]

--- a/src/display_iterator_options.rs
+++ b/src/display_iterator_options.rs
@@ -1,0 +1,53 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) struct DisplayIteratorOptions<'a> {
+    /// The maximum number of elements to display. by default, it is 5.
+    pub(crate) limit: Option<usize>,
+    /// The separator between elements. by default, it is ",".
+    pub(crate) separator: &'a str,
+    /// The left brace. by default, it is "[".
+    pub(crate) left_brace: &'a str,
+    /// The right brace. by default, it is "]".
+    pub(crate) right_brace: &'a str,
+    /// The ellipsis string. by default, it is "..".
+    pub(crate) ellipsis: &'a str,
+    /// The prefix for each element. by default, it is "".
+    pub(crate) elem_prefix: &'a str,
+    /// The suffix for each element. by default, it is "".
+    pub(crate) elem_suffix: &'a str,
+    /// Whether to show the total count when truncated. by default, it is false.
+    pub(crate) show_count: bool,
+}
+
+impl Default for DisplayIteratorOptions<'_> {
+    fn default() -> Self {
+        Self {
+            limit: None,
+            separator: ",",
+            left_brace: "[",
+            right_brace: "]",
+            ellipsis: "..",
+            elem_prefix: "",
+            elem_suffix: "",
+            show_count: false,
+        }
+    }
+}
+
+impl DisplayIteratorOptions<'_> {
+    pub(crate) fn limit(&self) -> usize {
+        self.limit.unwrap_or(5)
+    }
+}

--- a/src/display_slice.rs
+++ b/src/display_slice.rs
@@ -118,12 +118,12 @@ mod tests {
         let a = vec![1, 2, 3, 4, 5, 6];
         assert_eq!("[1,2,3,4,..,6]", DisplaySlice::new(&a).to_string());
 
-        let a = vec![1, 2, 3, 4, 5, 6, 7];
+        let a = [1, 2, 3, 4, 5, 6, 7];
         assert_eq!("[1,2,3,4,..,7]", DisplaySlice::new(&a).to_string());
 
         // with limit
 
-        let a = vec![1, 2, 3, 4, 5, 6, 7];
+        let a = [1, 2, 3, 4, 5, 6, 7];
         assert_eq!(
             "[1,..,7]",
             DisplaySlice::new(&a).at_most(Some(2)).to_string()
@@ -140,10 +140,10 @@ mod tests {
 
     #[test]
     fn test_display_slice_separator() {
-        let a = vec![1, 2, 3];
+        let a = [1, 2, 3];
         assert_eq!("[1, 2, 3]", a.display().sep(", ").to_string());
 
-        let a = vec![1, 2, 3, 4, 5, 6];
+        let a = [1, 2, 3, 4, 5, 6];
         assert_eq!("[1, 2, 3, 4, .., 6]", a.display().sep(", ").to_string());
 
         assert_eq!("[1|..|6]", a.display_n(2).sep("|").to_string());
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_display_slice_ellipsis() {
-        let a = vec![1, 2, 3, 4, 5, 6];
+        let a = [1, 2, 3, 4, 5, 6];
 
         // Custom ellipsis "..."
         assert_eq!("[1,2,3,4,...,6]", a.display().ellipsis("...").to_string());
@@ -188,13 +188,13 @@ mod tests {
 
     #[test]
     fn test_display_slice_elem() {
-        let a = vec![1, 2, 3];
+        let a = [1, 2, 3];
 
         // Quotes
         assert_eq!("['1','2','3']", a.display().elem("'", "'").to_string());
 
         // Quotes with truncation
-        let b = vec![1, 2, 3, 4, 5, 6];
+        let b = [1, 2, 3, 4, 5, 6];
         assert_eq!(
             "['1','2','3','4',..,'6']",
             b.display().elem("'", "'").to_string()
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn test_display_slice_show_count() {
-        let a = vec![1, 2, 3, 4, 5, 6, 7];
+        let a = [1, 2, 3, 4, 5, 6, 7];
 
         // Basic
         assert_eq!(
@@ -230,7 +230,7 @@ mod tests {
         assert_eq!("[..(7 total),7]", a.display_n(1).show_count().to_string());
 
         // No truncation (len <= limit): count not shown
-        let c = vec![1, 2, 3];
+        let c = [1, 2, 3];
         assert_eq!("[1,2,3]", c.display().show_count().to_string());
 
         // Combined with custom ellipsis
@@ -254,13 +254,13 @@ mod tests {
 
     #[test]
     fn test_display_slice_braces() {
-        let a = vec![1, 2, 3];
+        let a = [1, 2, 3];
 
         // Custom braces, no truncation
         assert_eq!("{1,2,3}", a.display().braces("{", "}").to_string());
 
         // Custom braces with truncation
-        let b = vec![1, 2, 3, 4, 5, 6];
+        let b = [1, 2, 3, 4, 5, 6];
         assert_eq!("{1,2,3,4,..,6}", b.display().braces("{", "}").to_string());
 
         // Custom braces combined with custom separator

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@
 
 mod display_btreeset;
 mod display_into_iter;
+mod display_iterator_options;
 pub mod display_option;
 mod display_result;
 pub mod display_slice;


### PR DESCRIPTION

## Changelog

##### refactor: extract formatting options into `DisplayIteratorOptions`
Move the formatting fields (limit, separator, braces, ellipsis, element
prefix/suffix, show_count) out of `DisplayIntoIter` into a dedicated
`DisplayIteratorOptions` struct. This separates the data source concern
(what to iterate) from the presentation concern (how to format), making
the options reusable and the iterator struct smaller.

---

- Improvement
