### PR TITLE
chore: remove `cargo-audit` from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,3 @@ jobs:
           args: --all --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings"
-
-
-      - shell: bash
-        run: cargo install cargo-audit --locked
-
-
-      - name: Audit dependencies
-        shell: bash
-        # if: "!contains(github.event.head_commit.message, 'skip audit')"
-        run: cargo audit --db ./target/advisory-db


### PR DESCRIPTION

## Changelog

##### chore: remove `cargo-audit` from CI
The `cargo-audit` step consistently fails due to toolchain version
mismatches — its transitive dependencies now require rustc 1.88+ while
the CI runner pins an older nightly. Remove the audit step entirely
rather than chasing version pins.

---


