### PR TITLE
chore: Bump ver: 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,3 @@ jobs:
           args: --all --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings"
-
-
-      - shell: bash
-        run: cargo install cargo-audit --locked
-
-
-      - name: Audit dependencies
-        shell: bash
-        # if: "!contains(github.event.head_commit.message, 'skip audit')"
-        run: cargo audit --db ./target/advisory-db

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-more"
 description = "helper to display various types"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION

## Changelog

##### chore: Bump ver: 0.2.6

##### chore: remove `cargo-audit` from CI
The `cargo-audit` step consistently fails due to toolchain version
mismatches — its transitive dependencies now require rustc 1.88+ while
the CI runner pins an older nightly. Remove the audit step entirely
rather than chasing version pins.

---


